### PR TITLE
Use shopify.com domain restriction for OAuth.

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,4 @@
 require 'openid/store/filesystem'
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_apps, :store => OpenID::Store::Filesystem.new('./tmp'), :name => 'g', :domain => 'jadedpixel.com'
+  provider :google_apps, :store => OpenID::Store::Filesystem.new('./tmp'), :name => 'g', :domain => 'shopify.com'
 end


### PR DESCRIPTION
Use shopify.com domain for OAuth. r: @csaunders Not sure if this is alive, but wtv.
